### PR TITLE
fix: [NSN-1360] - Get back in deployable state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.11-alpine3.9 as builder
 # Inspired from https://github.com/DarthSim/imgproxy/blob/a344a47f0fa4b492e0a54db047a53991c05419ac/Dockerfile
 # Note: All the dependencies have been adjusted one way or the other
 
-ENV IMAGEMAGICK_VERSION "7.0.8-68"
+ENV IMAGEMAGICK_VERSION "7.1.0-43"
 ENV VIPS_VERSION "8.7.4"
 
 # Install dependencies
@@ -14,7 +14,7 @@ RUN apk --update add --no-cache \
 # Build ImageMagick
 RUN cd /root \
 	&& mkdir ImageMagick \
-	&& wget https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz \
+	&& wget https://imagemagick.org/archive/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz \
     && tar -xf  ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz \
 	&& cd ImageMagick-${IMAGEMAGICK_VERSION} \
 	&& MKDIR_P="/bin/mkdir -p" ./configure \


### PR DESCRIPTION
Fix for imagemagick changing their link causing a 404 in the docker build.